### PR TITLE
`Formatter::filesize()` support for robibyte (RiB) …

### DIFF
--- a/packages/formatter/defaults/translations/en/messages.php
+++ b/packages/formatter/defaults/translations/en/messages.php
@@ -11,6 +11,8 @@ return [
         'EiB' => 'EiB',
         'ZiB' => 'ZiB',
         'YiB' => 'YiB',
+        'RiB' => 'RiB',
+        'QiB' => 'QiB',
     ],
     'disksize' => [
         'B'  => 'B',

--- a/packages/formatter/src/Formatter.php
+++ b/packages/formatter/src/Formatter.php
@@ -343,8 +343,10 @@ class Formatter {
 
     /**
      * Formats number of bytes into units based on powers of 2 (kibibyte, mebibyte, etc).
+     *
+     * @param numeric-string|float|int<0, max>|null $bytes
      */
-    public function filesize(?int $bytes, int $decimals = null): string {
+    public function filesize(string|float|int|null $bytes, int $decimals = null): string {
         return $this->formatFilesize(
             $bytes,
             $decimals ?: Cast::toInt($this->getOptions(static::Filesize, 2)),
@@ -359,6 +361,8 @@ class Formatter {
                 $this->getTranslation(['filesize.EiB', 'EiB']),
                 $this->getTranslation(['filesize.ZiB', 'ZiB']),
                 $this->getTranslation(['filesize.YiB', 'YiB']),
+                $this->getTranslation(['filesize.RiB', 'RiB']),
+                $this->getTranslation(['filesize.QiB', 'QiB']),
             ],
         );
     }

--- a/packages/formatter/src/FormatterTest.php
+++ b/packages/formatter/src/FormatterTest.php
@@ -11,6 +11,7 @@ use Override;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 use function config;
+use function pow;
 use function str_replace;
 
 use const PHP_INT_MAX;
@@ -274,6 +275,13 @@ class FormatterTest extends TestCase {
         self::assertEquals('10.00 GiB', $this->formatter->filesize(10 * 1024 * 1024 * 1024, 2));
         self::assertEquals('0.87 EiB', $this->formatter->filesize(999_999_999_999_999_999, 2));
         self::assertEquals('8.00 EiB', $this->formatter->filesize(PHP_INT_MAX, 2));
+        self::assertEquals('10.00 QiB', $this->formatter->filesize(10 * pow(2, 100), 2));
+        self::assertEquals('10.00 QiB', $this->formatter->filesize('12676506002282294014967032053760', 2));
+        self::assertEquals('100.00 QiB', $this->formatter->filesize('126765060022822940149670320537699', 2));
+        self::assertEquals(
+            '10,000.00 QiB',
+            $this->formatter->filesize(10 * 1000 * pow(2, 100), 2),
+        );
     }
 
     public function testDisksize(): void {


### PR DESCRIPTION
…and quebibyte (QiB).